### PR TITLE
docs: add warnings about special characters in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,13 +33,13 @@ pip install -r requirements.txt
 `zjuical.py` 即为主程序，使用以下命令运行：
 
 ```sh
-python zjuical.py -u [username] -p [password]
+python zjuical.py -u [username] -p '[password]'
 ```
 
-其中 `[username]` 为浙江大学统一身份认证用户名（即学号），`[password]` 为统一认证密码，无需方括号。例如，假如你的学号为 3230100000，密码为 123456，那么你需要运行：
+其中 `[username]` 为浙江大学统一身份认证用户名（即学号），`[password]` 为统一认证密码，无需方括号，外部单引号需保留（防止密码中有特殊字符导致参数传递错误）。例如，假如你的学号为 3230100000，密码为 123456，那么你需要运行：
 
 ```sh
-python zjuical.py -u 3230100000 -p 123456
+python zjuical.py -u 3230100000 -p '123456'
 ```
 
 运行后即可在当前目录下生成 `zjuical.ics` 文件，导入到日历应用即可，更多的参数请使用 `python zjuical.py --help` 查看。


### PR DESCRIPTION
密码中可能存在一些特殊字符导致参数传递错误，对README进行了细微修改，大一小登，格式流程若有不规范还请包涵