### PR TITLE
fix: correct description of Move tweak

### DIFF
--- a/course/course.py
+++ b/course/course.py
@@ -202,7 +202,7 @@ class CourseTable:
                 elif tweak.TweakType == TweakMethod.Move:
                     shadowDates[tweak.To] = tweak.From
                     del shadowDates[tweak.From]
-                    modDescriptions[tweak.To] = tweak.Description
+                    modDescriptions[tweak.From] = tweak.Description
                 elif tweak.TweakType == TweakMethod.Exchange:
                     shadowDates[tweak.To] = tweak.From
                     shadowDates[tweak.From] = tweak.To


### PR DESCRIPTION
before: moved courses cannot be added special description correctly

<img width="907" height="448" alt="image" src="https://github.com/user-attachments/assets/d96f0678-28c0-47e2-b3c1-6cf17804e30e" />

after fix:

<img width="907" height="590" alt="image" src="https://github.com/user-attachments/assets/e31683cb-545b-4cb9-97c0-10c516c222be" />
